### PR TITLE
Fix for SW-45; log rotation

### DIFF
--- a/software/openvisualizer/bin/moteStateGui/logging.conf
+++ b/software/openvisualizer/bin/moteStateGui/logging.conf
@@ -20,9 +20,8 @@ keys=std,console
 
 [handler_std]
 class=handlers.RotatingFileHandler
-maxBytes=200000
-backupCount=5
-args=('%(logDir)s/moteStateGui.log',)
+# args: filename, open mode, max file size, backup file count
+args=('%(logDir)s/moteStateGui.log', 'a', 200000, 5)
 formatter=std
 
 [handler_console]


### PR DESCRIPTION
Resolves SW-45.

Must place all handler class arguments in args key. maxBytes and backupCount keys are not used by logging conf file reader.
