### PR TITLE
SW-61. Make openTunLinux handling of v6ToInternet event like Windows imp...

### DIFF
--- a/software/openvisualizer/openLbr/openLbr.py
+++ b/software/openvisualizer/openLbr/openLbr.py
@@ -275,7 +275,7 @@ class OpenLbr(eventBusClient.eventBusClient):
             # assemble the packet and dispatch it again as nobody answer 
             ipv6pkt=self.reassemble_ipv6_packet(ipv6dic)       
             
-            self._dispatchProtocol('v6ToInternet',ipv6pkt)
+            self.dispatch('v6ToInternet',ipv6pkt)
             
         except (ValueError,NotImplementedError) as err:
             log.error(err)

--- a/software/openvisualizer/openTun/openTunLinux.py
+++ b/software/openvisualizer/openTun/openTunLinux.py
@@ -169,8 +169,14 @@ class OpenTunLinux(eventBusClient.eventBusClient):
         # convert data to string
         data  = ''.join([chr(b) for b in data])
         
-        # write over tuntap interface
-        os.write(self.tunIf, data)
+        try:
+            # write over tuntap interface
+            os.write(self.tunIf, data)
+            log.debug("data dispatched to tun correctly {0}, {1}".format(signal,sender))
+        except Exception as err:
+            print err
+            log.error(err)
+            raise ValueError('Error writing to TUN, cannot send data from {0}'.format(sender))
     
     def _v6ToMesh_notif(self,data):
         '''


### PR DESCRIPTION
...l.

openTunLinux.py -- Add try/except handler, and throw ValueError.
openLbr.py ------- Use dispatch() rather than _dispatchProtocol() for
v6ToInternet signal since function call does not use return value.
