### PR TITLE
SW-66. Close app threads when click system close ('X') button

### DIFF
--- a/software/openUI/OpenWindow.py
+++ b/software/openUI/OpenWindow.py
@@ -3,13 +3,16 @@ import Tkinter
 
 class OpenWindow(Tkinter.Tk):
     
-    def __init__(self,appName):
+    def __init__(self,appName,app):
         
         # initialize the parent class
         Tkinter.Tk.__init__(self)
         
         # assign a title to this window
         self.title("{0} - OpenWSN project".format(appName))
+        
+        # retain a reference to the calling application so we can close
+        self.app = app
         
         # set a function to call when "x" close button is pressed
         self.protocol('WM_DELETE_WINDOW',self._closeWindow)
@@ -86,13 +89,8 @@ class OpenWindow(Tkinter.Tk):
         self.update_idletasks()
     
     def _closeWindow(self):
-        # stop the mainloop and close this window
+        self.app.close()
         self.quit()
-        
-        # TODO: call teardown functions?
-        
-        # quit
-        sys.exit()
     
 ###############################################################################
 

--- a/software/openvisualizer/RPL/RPL.py
+++ b/software/openvisualizer/RPL/RPL.py
@@ -88,6 +88,9 @@ class RPL(eventBusClient.eventBusClient):
     
     #======================== public ==========================================
     
+    def close(self):
+        self.timer.cancel()
+    
     #======================== private =========================================
     
     #==== handle EventBus notifications
@@ -141,7 +144,8 @@ class RPL(eventBusClient.eventBusClient):
         \param[in] interval In how many seconds the DIO is scheduled to be
             sent.
         '''
-        self.timer = threading.Timer(interval,self._cycleDIO)
+        self.timer      = threading.Timer(interval,self._cycleDIO)
+        self.timer.name = 'DIO Timer'
         self.timer.start()
         
     def _cycleDIO(self):

--- a/software/openvisualizer/bin/openVisualizerGui/logging.conf
+++ b/software/openvisualizer/bin/openVisualizerGui/logging.conf
@@ -32,7 +32,7 @@ formatter=console
 #============================ loggers =========================================
 
 [loggers]
-keys=root,eventBusMonitor,openTunWindows,openTunLinux,eventBusClient,lbrClient,moteConnector,moteProbe,moteProbeUtils,moteState,openLbr,OpenParser,Parser,OpenHdlc,ParserData,ParserInfoErrorCritical,ParserStatus,RPL,SourceRoute,moteProbeSerialThread,udpLatency
+keys=root,eventBusMonitor,openTunWindows,openTunLinux,eventBusClient,lbrClient,moteConnector,moteProbe,moteProbeUtils,moteState,openLbr,OpenParser,Parser,OpenHdlc,ParserData,ParserInfoErrorCritical,ParserStatus,RPL,SourceRoute,udpLatency,openVisualizerGui
 
 [logger_root]
 level=ERROR
@@ -152,9 +152,9 @@ handlers=std
 propagate=0
 qualname=OpenHdlc
 
-[logger_moteProbeSerialThread]
-level=DEBUG
+[logger_openVisualizerGui]
+level=INFO
 handlers=std
 propagate=0
-qualname=moteProbeSerialThread
+qualname=openVisualizerGui
 

--- a/software/openvisualizer/openTun/openTun.py
+++ b/software/openvisualizer/openTun/openTun.py
@@ -39,4 +39,5 @@ class OpenTun():
     
     #======================== public ==========================================
     
-  
+    def close(self):
+        self.openTun.close()

--- a/software/openvisualizer/openTun/openTunWindows.py
+++ b/software/openvisualizer/openTun/openTunWindows.py
@@ -8,6 +8,7 @@ log.addHandler(NullHandler())
 
 import threading
 import time
+import socket
 import traceback
 import sys
 
@@ -72,7 +73,7 @@ class TunReadThread(threading.Thread):
         threading.Thread.__init__(self)
         
         # give this thread a name
-        self.name                 = 'readThread'
+        self.name                 = 'TunReadThread'
         
         # start myself
         self.start()
@@ -168,6 +169,28 @@ class OpenTunWindows(eventBusClient.eventBusClient):
         )
     
     #======================== public ==========================================
+    
+    def close(self):
+        
+        self.tunReadThread.close()
+        
+        # Send a packet to openTun interface to break out of blocking read.
+        attempts = 0
+        while self.tunReadThread.isAlive() and attempts < 3:
+            attempts += 1
+            try:
+                log.debug('Sending UDP packet to close openTun')
+                sock = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
+                # Destination must route through the TUN host, but not be the host itself.
+                # OK if host does not really exist.
+                dst      = openTun.IPV6PREFIX + openTun.IPV6HOST
+                dst[15] += 1
+                # Payload and destination port are arbitrary
+                sock.sendto('stop', (u.formatIPv6Addr(dst),18004))
+                # Give thread some time to exit
+                time.sleep(0.05)
+            except Exception as err:
+                log.error('Unable to send UDP to close tunReadThread: {0}'.join(err))
     
     #======================== private =========================================
     

--- a/software/openvisualizer/openvisualizer_utils.py
+++ b/software/openvisualizer/openvisualizer_utils.py
@@ -1,4 +1,5 @@
 import traceback
+import threading
 
 def buf2int(buf):
     '''
@@ -39,6 +40,12 @@ def formatIPv6Addr(addr):
     
 def formatAddr(addr):
     return '-'.join(["%02x" % b for b in addr])
+    
+def formatThreadList():
+    return '\nActive threads ({0})\n   {1}'.format(
+        threading.activeCount(),
+        '\n   '.join([t.name for t in threading.enumerate()]),
+    )
 
 #===== parsing
 


### PR DESCRIPTION
openVisualizerGui.py --
   OpenVisualizerGui_app: Close thread-based components openTun, RPL,
      and moteProbes.
   OpenVisualizerGui: Remove direct references to
      individual modules, instead reference indirectly through app.
   Also add logging capability.

moteProbe.py -- Add flag variable to stop processing serial comm. Also,
daemonize thread if in simulator mode. Otherwise, moteProbes sometimes
persist.

openTunLinux.py and
openTunWindows.py -- Finish read thread by sending a UDP packet to TUN
interface, which breaks out of blocking read.

RPL.py -- Cancel timer

OpenWindow.py -- Add reference to application so can close from UI
openvisualizer_utils.py -- Add function to print a list of active
   threads.
logging.conf -- Add openVisualizerGui and remove moteProbeSerialThread
