### PR TITLE
SW-121. Automated copy of sim firmware files

### DIFF
--- a/software/openvisualizer/SConstruct
+++ b/software/openvisualizer/SConstruct
@@ -8,6 +8,7 @@ import os
 import subprocess
 import sys
 import SCons
+import sconsUtils
 
 #============================ banner ==========================================
 
@@ -92,6 +93,10 @@ env = Environment(
 # subdirectory via SConscript.
 env['ROOT_BUILD_DIR'] = os.path.join(os.getcwd(), 'build')
 
+# External openwsn-fw repository directory. An environment variable makes it
+# easy to change since it depends on the host running this script.
+env['FW_DIR']         = os.path.join('..', '..', '..', 'openwsn-fw')
+
 def default(env,target,source): 
     print SCons.Script.help_text
     
@@ -159,32 +164,7 @@ env['DATA_DIRS']  = runnerEnv['DATA_DIRS']
 
 #===== copy-simfw
 
-def copySimfw(env):
-    '''
-    Copies the firmware Python extension module from the firmware repository
-    into the software data directory.
-    '''
-    # root of the openwsn-fw clone
-    fwdir   = os.path.join('..', '..', '..', 'openwsn-fw')
-    # in openwsn-fw, directory containing 'openwsnmodule_obj.h'
-    incdir  = os.path.join(fwdir, 'firmware','openos','bsp','boards','python')
-    # in openwsn-fw, directory containing extension library
-    libdir  = os.path.join(fwdir, 'firmware','openos','projects','common')
-    # extension of the library
-    libext  = 'pyd' if sys.platform == 'win32' else 'so'
-    # directory in openwsn-sw to copy the files into
-    datadir = os.path.join(appdir, 'sim_files')
-    
-    return env.Command(
-        'sim',
-        '', 
-        [
-            Copy(datadir, os.path.join(incdir, 'openwsnmodule_obj.h')),
-            Copy(datadir, os.path.join(libdir, 'oos_openwsn.{0}'.format(libext))),
-        ]
-    )
-
-Alias('copy-simfw', copySimfw(env))
+Alias('copy-simfw', sconsUtils.copySimfw(env, 'simcopy'))
 
 #===== sdist
 

--- a/software/openvisualizer/bin/openVisualizerApp/SConscript
+++ b/software/openvisualizer/bin/openVisualizerApp/SConscript
@@ -10,6 +10,7 @@ Provides rungui, runcli, and runweb targets.
 
 import os
 import subprocess
+import sconsUtils
 
 Import('env')
 
@@ -76,10 +77,12 @@ def setupUiRunner(env, uiFile, dataDirs):
     Sets up dependencies for data files required to run an OpenVisualizer 
     UI. The data files are copied to the environment's BUILD_DIR.
     
+    * Copies simulation firmware to the sim_files data directory if running
+      a simulation.
     * Creates commands to copy conf files unless they exist already. The 
-    user may have edited them.
+      user may have edited them.
     * Creates commands to copy the provided static data directories 
-    unconditionally.
+      unconditionally.
     
     :param uiFile:   Filename to run in openVisualizerApp directory
     :param dataDirs: Dirs containing static data
@@ -90,6 +93,12 @@ def setupUiRunner(env, uiFile, dataDirs):
     env.Append(BUILDERS = {'RunUi' : Builder(action = uiRunner)})
     
     targets = env.RunUi(uiFile)
+
+    if env['SIMOPT'] or env['SIMCOUNT']:
+        # Appending uiFile to pseudo-target to make it unique.
+        simfwTarget = 'simui-{0}'.format(uiFile)
+        Depends(targets, simfwTarget)
+        sconsUtils.copySimfw(env, simfwTarget)
     
     for node in (env['CONF_FILES'] + env['DATA_FILES']):
         bldNode = os.path.join(env['BUILD_DIR'], node)

--- a/software/openvisualizer/site_scons/sconsUtils.py
+++ b/software/openvisualizer/site_scons/sconsUtils.py
@@ -1,0 +1,38 @@
+from SCons.Script import *
+import os
+
+'''
+Includes common SCons utilities, usable by SConstruct and any SConscript.
+'''
+
+def copySimfw(env, target):
+    '''
+    Copies the firmware Python extension module from where it was built in the
+    openwsn-fw firmware repository, into the openVisualizerApp data directory,
+    which is software repository's home for data files.
+    
+    Assumes the environment includes an 'FW_DIR' entry with the path to the 
+    openwsn-fw repository.
+    
+    :param target: Provides a unique pseudo-target for the Command to perform 
+                   the copy.
+    '''
+    # in openwsn-fw, directory containing 'openwsnmodule_obj.h'
+    incdir  = os.path.join(env['FW_DIR'], 'firmware','openos','bsp','boards','python')
+    # in openwsn-fw, directory containing extension library
+    libdir  = os.path.join(env['FW_DIR'], 'firmware','openos','projects','common')
+    # extension of the library
+    libext  = 'pyd' if sys.platform == 'win32' else 'so'
+    # directory in openwsn-sw to copy the files into, relative to 
+    # software/openvisualizer
+    datadir = os.path.join('bin', 'openVisualizerApp', 'sim_files')
+    
+    return env.Command(
+        target,
+        '', 
+        [
+            Copy(datadir, os.path.join(incdir, 'openwsnmodule_obj.h')),
+            Copy(datadir, os.path.join(libdir, 'oos_openwsn.{0}'.format(libext))),
+        ]
+    )
+


### PR DESCRIPTION
Automatically copies sim firmware files from openwsn-fw repository
checkout when run a UI with the --sim or --simCount options. Eliminates
requirement to first run 'scons copy-simfw'. However, copy-simfw target
still is available.

Added common SCons script module, site_scons/sconsUtils.py for
copySimfw() since this function is used by both SConstruct and
openVisualizerApp/SConscript.
