### PR TITLE
SW-130. Distribute simulation module variants, and select at install time

### DIFF
--- a/software/openvisualizer/SConstruct
+++ b/software/openvisualizer/SConstruct
@@ -5,6 +5,7 @@
 # https://openwsn.atlassian.net/wiki/display/OW/License
 
 import os
+import platform
 import subprocess
 import sys
 import SCons
@@ -45,6 +46,8 @@ Targets:
         Options
           --sim         Run in simulator mode with default count of motes.
           --simCount=n  Run in simulator mode with 'n' motes.
+          --nosimcopy   Skips copying simulation firmware at startup from the
+                        openwsn-fw directory.
           --ovdebug     Enable debug mode; more detailed logging
           
         Web UI only
@@ -57,6 +60,13 @@ Targets:
         Copy files for the simulator, generated from an OpenWSN firmware 
         build on this host. Assumes firmware top-level directory is 
         '../../../openwsn-fw'.
+        
+        Options
+          --simhost=<platform-os> 
+                        Platform and OS for firmware; supports creation of a
+                        setup package with multiple variants. Defaults to the
+                        platform-OS on which SCons is running. Valid entries:
+                        amd64-linux, x86-linux, amd64-windows, x86-windows
     
     sdist:
         Generate a standard Python source distribution archive (for 
@@ -118,6 +128,12 @@ AddOption('--simCount',
     type      = 'int')
 runnerEnv['SIMCOUNT'] = GetOption('simCount')
 
+AddOption('--nosimcopy',
+    dest      = 'simcopyOpt',
+    default   = True,
+    action    = 'store_true')
+runnerEnv['SIMCOPYOPT'] = GetOption('simcopyOpt')
+
 AddOption('--trace',
     dest      = 'traceOpt',
     default   = False,
@@ -148,7 +164,30 @@ runnerEnv['PORTOPT'] = GetOption('portOpt')
 
 #============================ SCons targets ===================================
 
+#===== copy-simfw
+
+simhosts = ['amd64-linux','x86-linux','amd64-windows','x86-windows']
+if os.name == 'nt':
+    defaultIndex = 2 if platform.architecture()[0]=='64bit' else 3
+else:
+    defaultIndex = 0 if platform.architecture()[0]=='64bit' else 1
+
+AddOption('--simhost',
+    dest      = 'simhostOpt',
+    default   = simhosts[defaultIndex],
+    type      = 'choice',
+    choices   = simhosts)
+
+# Must copy SIMHOSTOPT to runner environment since it also reads sconsUtils.py.
+env['SIMHOSTOPT']       = GetOption('simhostOpt')
+runnerEnv['SIMHOSTOPT'] = env['SIMHOSTOPT']
+
+Alias('copy-simfw', sconsUtils.copySimfw(env, 'simcopy'))
+
 #===== rungui, runcli, runweb
+
+# Must define run targets below the copy-simfw target so SIMHOSTOPT is available. 
+# Run targets may copy simulation firmware before starting.
 
 appdir = os.path.join('bin', 'openVisualizerApp')
 
@@ -161,10 +200,6 @@ SConscript(
 # dist targets below.
 env['CONF_FILES'] = runnerEnv['CONF_FILES']
 env['DATA_DIRS']  = runnerEnv['DATA_DIRS']
-
-#===== copy-simfw
-
-Alias('copy-simfw', sconsUtils.copySimfw(env, 'simcopy'))
 
 #===== sdist
 

--- a/software/openvisualizer/bin/openVisualizerApp/SConscript
+++ b/software/openvisualizer/bin/openVisualizerApp/SConscript
@@ -94,7 +94,7 @@ def setupUiRunner(env, uiFile, dataDirs):
     
     targets = env.RunUi(uiFile)
 
-    if env['SIMOPT'] or env['SIMCOUNT']:
+    if (env['SIMOPT'] or env['SIMCOUNT']) and env['SIMCOPYOPT']:
         # Appending uiFile to pseudo-target to make it unique.
         simfwTarget = 'simui-{0}'.format(uiFile)
         Depends(targets, simfwTarget)

--- a/software/openvisualizer/site_scons/sconsUtils.py
+++ b/software/openvisualizer/site_scons/sconsUtils.py
@@ -1,5 +1,6 @@
 from SCons.Script import *
 import os
+import platform
 
 '''
 Includes common SCons utilities, usable by SConstruct and any SConscript.
@@ -8,31 +9,50 @@ Includes common SCons utilities, usable by SConstruct and any SConscript.
 def copySimfw(env, target):
     '''
     Copies the firmware Python extension module from where it was built in the
-    openwsn-fw firmware repository, into the openVisualizerApp data directory,
-    which is software repository's home for data files.
+    openwsn-fw firmware repository, into the openVisualizerApp data/sim_files 
+    directory tree. Stores architecture-specific module versions (amd64, x86)
+    into an OS-specific subdirectory of sim_files. Also copies the file
+    directly into the sim_files directory for local use if architecture and OS 
+    match.
     
-    Assumes the environment includes an 'FW_DIR' entry with the path to the 
-    openwsn-fw repository.
+    Assumes the environment includes two entries:
+    * 'FW_DIR'     entry with the path to the openwsn-fw repository
+    * 'SIMHOSTOPT' architecture and OS of the extension module, like 'amd64-linux'
     
     :param target: Provides a unique pseudo-target for the Command to perform 
                    the copy.
     '''
     # in openwsn-fw, directory containing 'openwsnmodule_obj.h'
-    incdir  = os.path.join(env['FW_DIR'], 'firmware','openos','bsp','boards','python')
+    incdir    = os.path.join(env['FW_DIR'], 'firmware','openos','bsp','boards','python')
     # in openwsn-fw, directory containing extension library
-    libdir  = os.path.join(env['FW_DIR'], 'firmware','openos','projects','common')
-    # extension of the library
-    libext  = 'pyd' if sys.platform == 'win32' else 'so'
-    # directory in openwsn-sw to copy the files into, relative to 
-    # software/openvisualizer
-    datadir = os.path.join('bin', 'openVisualizerApp', 'sim_files')
-    
-    return env.Command(
-        target,
-        '', 
-        [
-            Copy(datadir, os.path.join(incdir, 'openwsnmodule_obj.h')),
-            Copy(datadir, os.path.join(libdir, 'oos_openwsn.{0}'.format(libext))),
-        ]
-    )
+    libdir    = os.path.join(env['FW_DIR'], 'firmware','openos','projects','common')
 
+    # Build source and destination pathnames.
+    archAndOs = env['SIMHOSTOPT'].split('-')
+    libext    = 'pyd' if archAndOs[1]=='windows' else 'so'
+    srcname   = 'oos_openwsn.{0}'.format(libext)
+    destname  = 'oos_openwsn-{0}.{1}'.format(archAndOs[0], libext)
+    simdir    = os.path.join('bin', 'openVisualizerApp', 'sim_files')
+    destdir   = os.path.join(simdir, archAndOs[1])
+    
+    cmdlist   = [
+                Copy(simdir, os.path.join(incdir, 'openwsnmodule_obj.h')),
+                Mkdir(os.path.join(destdir)),
+                Copy(os.path.join(destdir, destname), os.path.join(libdir, srcname)),
+                ]
+                
+    # Copy the module directly to sim_files directory if it matches this host.
+    if archAndOs[0] == 'amd64':
+        archMatch = platform.architecture()[0]=='64bit'
+    else:
+        archMatch = platform.architecture()[0]=='32bit'
+    if archAndOs[1] == 'windows':
+        osMatch = os.name=='nt'
+    else:
+        osMatch = os.name=='posix'
+
+    if archMatch and osMatch:
+        cmdlist.append( Copy(simdir, os.path.join(libdir, srcname)) )
+    
+    return env.Command(target, '', cmdlist)
+        


### PR DESCRIPTION
Changes include:
- Added --simhost option for SCons copy-simfw target. Copies current
  openwsn-fw simulation firmware to a 'linux' or 'windows' subdirectory of
  'sim_files' Renames the file to include CPU architecture, either 'amd64'
  or 'x86'.
- Added --nosimcopy option to SCons 'run' targets to avoid automatically
  copying cross-built simulation firmware in openwsn-fw.
- Updated setup 'install' target to select and copy the proper simulation
  firmware variant from the linux/windows directories, up to the
  'sim_files' directory. Implemented with a custom 'build_py' class that
  extends the setuptools default when building the package data directory.
  Exclude the firmware variant directories from installation.
