### PR TITLE
SW-261. Fix deprecation warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
 before_install:
  - sudo apt-get update -qq
  - sudo apt-get install -qq python-tk
-install: pip install -r requirements.txt --use-mirrors
+install: pip install -r requirements.txt
 
 # Whitelist
 #branches:


### PR DESCRIPTION
pip install -r requirements.txt --use-mirrors
DEPRECATION: --use-mirrors has been deprecated and will be removed in
the future. Explicit uses of --index-url and/or --extra-index-url is
suggested.

You can see this deprecation warning here : 
https://travis-ci.org/openwsn-berkeley/openwsn-sw/builds/144916087