### PR TITLE
FW-574. Use description instead of number when printing sixtop return code and state

### DIFF
--- a/software/openvisualizer/openvisualizer/moteConnector/GenStackDefines.py
+++ b/software/openvisualizer/openvisualizer/moteConnector/GenStackDefines.py
@@ -26,8 +26,9 @@ import time
 
 #============================ defines =========================================
 
-INPUT_FILE    = os.path.join('..','..','..','..','..','openwsn-fw','inc','opendefs.h')
-OUTPUT_FILE   = 'StackDefines.py'
+INPUT_FILE        = os.path.join('..','..','..','..','..','openwsn-fw','inc','opendefs.h')
+INPUT_FILE_SIXTOP = os.path.join('..','..','..','..','..','openwsn-fw','openstack','02b-MAChigh','sixtop.h')
+OUTPUT_FILE       = 'StackDefines.py'
 
 #============================ helpers =========================================
 
@@ -78,11 +79,58 @@ def genErrorDescriptions():
     
     return output
 
+def genSixtopReturnCodes():
+    
+    # find components code in openwsn.h
+    codesFound = []
+    for line in open(INPUT_FILE_SIXTOP,'r'):
+        m = re.search('\s*#define\s*IANA_6TOP_RC_(\S*)\s*(\S*)\s*\S*\s*(\S*)\s*\S*\s*([\S\s]*)',line)
+        if m:
+            name = m.group(3)
+            desc = m.group(4).strip()
+            try:
+                code = int(m.group(2),16)
+            except ValueError:
+                print "WARNING: {0} is not a hex number".format(m.group(2))
+            else:
+                codesFound.append((code,name))
+    
+    # turn into text
+    output  = ["sixtop_returncode = {"]
+    output += ["{0:>4}: \"{1}\",".format(a,b) for (a,b) in codesFound]
+    output += ["}"]
+    output  = '\n'.join(output)
+    
+    return output
+
+def genSixtopStateMachine():
+    
+    # find components code in openwsn.h
+    codesFound = []
+    for line in open(INPUT_FILE_SIXTOP,'r'):
+        m = re.search('\s*SIX_STATE_(\S*)\s*=\s*(\S*),\s*',line)
+        if m:
+            name = m.group(1)
+            try:
+                code = int(m.group(2),16)
+            except ValueError:
+                print "WARNING: {0} is not a hex number".format(m.group(2))
+            else:
+                codesFound.append((code,name))
+    
+    # turn into text
+    output  = ["sixtop_statemachine = {"]
+    output += ["{0:>4}: \"{1}\",".format(a,b) for (a,b) in codesFound]
+    output += ["}"]
+    output  = '\n'.join(output)
+    
+    return output
+
 #============================ main ============================================
 
 def main():
     
-    if os.path.exists(INPUT_FILE):
+    if os.path.exists(INPUT_FILE) and os.path.exists(INPUT_FILE_SIXTOP):
         # we can access the openwsn.h file
         
         # gather the information
@@ -95,6 +143,10 @@ def main():
         output += [genComponentCodes()]
         output += [""]
         output += [genErrorDescriptions()]
+        output += [""]
+        output += [genSixtopReturnCodes()]
+        output += [""]
+        output += [genSixtopStateMachine()]
         output += [""]
         output  = '\n'.join(output)
         

--- a/software/openvisualizer/openvisualizer/moteConnector/ParserInfoErrorCritical.py
+++ b/software/openvisualizer/openvisualizer/moteConnector/ParserInfoErrorCritical.py
@@ -85,6 +85,9 @@ class ParserInfoErrorCritical(Parser.Parser):
     
     def _translateErrorDescription(self,error_code,arg1,arg2):
         try:
+            if error_code == 60:
+                arg1 = StackDefines.sixtop_returncode[arg1]
+                arg2 = StackDefines.sixtop_statemachine[arg2]
             return StackDefines.errorDescriptions[error_code].format(arg1,arg2)
         except KeyError:
             return "unknown error {0} arg1={1} arg2={2}".format(error_code,arg1,arg2)

--- a/software/openvisualizer/openvisualizer/moteConnector/StackDefines.py
+++ b/software/openvisualizer/openvisualizer/moteConnector/StackDefines.py
@@ -1,6 +1,6 @@
 # DO NOT EDIT DIRECTLY!
 # This file was generated automatically by GenStackDefines.py
-# on Thu, 18 Jun 2015 23:18:40
+# on Thu, 13 Oct 2016 16:59:38
 #
 
 components = {
@@ -43,6 +43,7 @@ components = {
   36: "UINJECT",
   37: "RRT",
   38: "SECURITY",
+  39: "USERIALBRIDGE",
 }
 
 errorDescriptions = {
@@ -50,12 +51,12 @@ errorDescriptions = {
    2: "received an echo reply",
    3: "getData asks for too few bytes, maxNumBytes={0}, fill level={1}",
    4: "the input buffer has overflown",
-   5: "the command is not allowed, command = {0}",
+   5: "the command is not allowerd, command = {0}",
    6: "unknown transport protocol {0} (code location {1})",
    7: "wrong TCP state {0} (code location {1})",
    8: "TCP reset while in state {0} (code location {1})",
    9: "unsupported port number {0} (code location {1})",
-  10: "unexpected DAO (code location {0})",
+  10: "unexpected DAO (code location {0}). A change maybe happened on dagroot node.",
   11: "unsupported ICMPv6 type {0} (code location {1})",
   12: "unsupported 6LoWPAN parameter {1} at location {0}",
   13: "no next hop",
@@ -103,9 +104,36 @@ errorDescriptions = {
   55: "invalid packet frome radio, length {1} (code location {0})",
   56: "busy receiving when stop of serial activity, buffer input length {1} (code location {0})",
   57: "wrong CRC in input Buffer (input length {0})",
-  58: "frame received at asn {0} with timeCorrection of {1}",
+  58: "synchronized when received a packet",
   59: "security error on frameType {0}, code location {1}",
-  60: "sixtop return code {0} at sixtop state {1} ",
-  61: "6P count command returns Number of scheduled cells: {0}",
-  62: "6P List returns cells [({0},{1})]",
+  60: "sixtop return code {0} at sixtop state {1}",
+  61: "there are {0} cells to request mote",
+  62: "the cells reserved to request mote contains slot {0} and slot {1}",
+  63: "the slot {0} to be added is already in schedule",
+}
+
+sixtop_returncode = {
+   6: "RC_SUCCESS",
+   7: "RC_ERR_VER",
+   8: "RC_ERR_SFID",
+   9: "RC_ERR_BUSY",
+  10: "RC_ERROR_NORES",
+  11: "RC_ERR_RESET",
+  12: "RC_ERR",
+}
+
+sixtop_statemachine = {
+   0: "IDLE",
+   1: "SENDING_REQUEST",
+   2: "WAIT_ADDREQUEST_SENDDONE",
+   3: "WAIT_DELETEREQUEST_SENDDONE",
+   4: "WAIT_COUNTREQUEST_SENDDONE",
+   5: "WAIT_LISTREQUEST_SENDDONE",
+   6: "WAIT_CLEARREQUEST_SENDDONE",
+   7: "WAIT_ADDRESPONSE",
+   8: "WAIT_DELETERESPONSE",
+   9: "WAIT_COUNTRESPONSE",
+  10: "WAIT_LISTRESPONSE",
+  11: "WAIT_CLEARRESPONSE",
+  12: "REQUEST_RECEIVED",
 }


### PR DESCRIPTION
-  Add description of sixtop return code and state machine. 
-  Replace the numbers in sixtop error description by sixtop description.