### PR TITLE
SW-289: to filter (i.e. drop) the ICMPv6 packets from tun0 to the mesh

### DIFF
--- a/software/openvisualizer/openvisualizer/openLbr/openLbr.py
+++ b/software/openvisualizer/openvisualizer/openLbr/openLbr.py
@@ -246,6 +246,14 @@ class OpenLbr(eventBusClient.eventBusClient):
             if log.isEnabledFor(logging.DEBUG):
                 log.debug(self._format_lowpan(lowpan,lowpan_bytes))
 
+            # don't forward the ICMPv6 packets to the motes (unsupported)
+            if (ipv6['next_header'] == self.IANA_ICMPv6) : #&& (lowpan['src_addr'] == ) : 
+                log.error('ICMPv6 packet to forward to {0}, The packet is dropped (not supported by openWSN)'.format(
+                    u.formatIPv6Addr(ipv6['dst_addr'])
+                    ))
+                log.error(self._format_lowpan(lowpan,lowpan_bytes))
+                return
+            
             #print "output:"
             #print lowpan_bytes
             # dispatch


### PR DESCRIPTION
A CoAP packet may generate an ICMPv6 reply if the corresponding port is closed. When forwarded in the mesh, it creates a mote's crash (after a "unsupported ICMPv6 type 1 (code location 1)")

Proposed solution: filter the ICMPv6 packet, which are dropped after a message in the log (message + the content of the packet)