### PR TITLE
SW-278: setDTR and setRTS removed

### DIFF
--- a/software/openvisualizer/openvisualizer/moteProbe/moteProbe.py
+++ b/software/openvisualizer/openvisualizer/moteProbe/moteProbe.py
@@ -189,8 +189,8 @@ class moteProbe(threading.Thread):
                 
                 if   self.mode==self.MODE_SERIAL:
                     self.serial = serial.Serial(self.serialport,self.baudrate,timeout=1)
-                    self.serial.setDTR(0)
-                    self.serial.setRTS(0)
+                    #self.serial.setDTR(0)
+                    #self.serial.setRTS(0)
                 elif self.mode==self.MODE_EMULATED:
                     self.serial = self.emulatedMote.bspUart
                 elif self.mode==self.MODE_IOTLAB:

--- a/software/openvisualizer/openvisualizer/moteProbe/moteProbe.py
+++ b/software/openvisualizer/openvisualizer/moteProbe/moteProbe.py
@@ -188,9 +188,7 @@ class moteProbe(threading.Thread):
                 log.info("open port {0}".format(self.portname))
                 
                 if   self.mode==self.MODE_SERIAL:
-                    self.serial = serial.Serial(self.serialport,self.baudrate,timeout=1)
-                    #self.serial.setDTR(0)
-                    #self.serial.setRTS(0)
+                    self.serial = serial.Serial(self.serialport,self.baudrate,timeout=1,rtscts=False,dsrdtr=False)
                 elif self.mode==self.MODE_EMULATED:
                     self.serial = self.emulatedMote.bspUart
                 elif self.mode==self.MODE_IOTLAB:


### PR DESCRIPTION
The `setDTR()` and `setRTS()` seem not work with the m3 motes (iotlab) and are deprecated.
Pyserial recommends the usage of `Serial(..., rtscts=False, dsrdtr=False)` when initializing the serial line

tested with m3 (real hardware) and python motes (emulation). 