### PR TITLE
FW-755. Add Content-Format for Wireshark to dissect the payload properly

### DIFF
--- a/software/openvisualizer/openvisualizer/JRC/JRC.py
+++ b/software/openvisualizer/openvisualizer/JRC/JRC.py
@@ -273,6 +273,9 @@ class joinResource(coapResource.coapResource):
         configuration[cojpDefines.COJP_PARAMETERS_LABELS_LLKEYSET]   = link_layer_keyset
         configuration_serialized = cbor.dumps(configuration)
 
+        contentFormat = o.ContentFormat(cformat=[d.FORMAT_CBOR])
+        respOptions += [contentFormat]
+
         respPayload     = [ord(b) for b in configuration_serialized]
 
         #objectSecurity = oscoap.objectSecurityOptionLookUp(options)


### PR DESCRIPTION
The Content-Format option is needed by Wireshark to dissect the payload of the Join Response as CBOR. Without this, the processing of F-Interop fails.

This is a temporary fix until whole processing of CBOR payloads is done within F-Interop.